### PR TITLE
Renaming active_group to activate_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Conditionally roll out features with Redis.
 
-Based on James Golick's 'rollout': http://github.com/jamesgolick/rollout
+Based on James Golick's [rollout](http://github.com/jamesgolick/rollout).
 
-# Usage
+## Usage
 
 Activate 20% of users to view 'feature':
 
@@ -17,10 +17,9 @@ Activate 20% of users to view 'feature':
 Works with groups and users. User should have an 'id', Proclaim uses it to
 verify whether user is 'active'.
 
-# Copyright
+## Copyright
 
-Copyright @ 2010 James Golick
+Copyright © 2010 James Golick
+Copyright © 2010 Curt Micol
 
-Copyright @ 2010 Curt Micol
-
-See LICENSE for details.
+See `LICENSE` for details.

--- a/proclaim.py
+++ b/proclaim.py
@@ -6,7 +6,7 @@ class Proclaim(object):
         self.redis = redis
         self.groups = { "all": [] }
 
-    def active_group(self, feature, group):
+    def activate_group(self, feature, group):
         if group in self.groups:
             self.redis.sadd(_group_key(feature), group)
 

--- a/test_proclaim.py
+++ b/test_proclaim.py
@@ -23,8 +23,8 @@ class TestProclaim(unittest.TestCase):
         assert len(self.proclaim.groups["b"]) == 3
         assert jim.id in self.proclaim.groups["a"]
 
-    def test_active_group(self):
-        self.proclaim.active_group("f1", "b")
+    def test_activate_group(self):
+        self.proclaim.activate_group("f1", "b")
         assert self.proclaim.is_active("f1", jim)
 
     def test_deactivate_group(self):


### PR DESCRIPTION
Renaming active_group to activate_group for consistency with activate_*.
